### PR TITLE
refactor: replace Multiselect with react-select in MultiSelectDropdown

### DIFF
--- a/component/common/MultiSelectDropdown/MultiSelectDropdown.module.css
+++ b/component/common/MultiSelectDropdown/MultiSelectDropdown.module.css
@@ -1,155 +1,33 @@
-/* MultiSelectDropdown.module.css */
-.container {
-    --highlight-color: var(--color-primary);
-    --error-color: var(--color-error);
-    --border-color: var(--color-border);
-    --background-hover: var(--color-background-secondary);
-    --text-color: var(--color-text-primary);
-    --placeholder-color: var(--color-placeholder);
-    --disabled-bg: var(--color-background-disabled);
-    position: relative;
-    margin-bottom: var(--spacing-lg);
-    width: 100%;
+.inputContainer {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
+    gap: var(--spacing-sm);
+    width: 100%;
+    position: relative;
 }
 
 .label {
-    display: block;
-    margin-bottom: var(--spacing-sm);
+    font-size: var(--font-size-base);
+    font-weight: 600;
     color: var(--color-text-label);
-    font-size: var(--font-size-sm);
-    font-weight: 500;
+    letter-spacing: var(--letter-spacing-wide);
 }
 
-.required {
-    color: var(--error-color);
-    margin-left: var(--spacing-xs);
+.requiredAsterisk {
+    color: var(--color-error);
+    margin-left: var(--spacing-xxs);
 }
 
-.wrapper {
+.selectWrapper {
     position: relative;
     width: 100%;
 }
 
 .errorMessage {
-    color: var(--error-color);
+    color: var(--color-error);
     font-size: var(--font-size-sm);
-    margin-top: var(--spacing-xs);
-    /*position: absolute;*/
-    /*bottom: -1.25rem;*/
-}
-
-/* Multiselect overrides */
-.multiselect {
-    width: 100%;
-}
-
-.multiselect :global(.searchBox) {
-    padding: var(--spacing-sm) var(--spacing-md);
-    min-height: 40px;
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius-md);
-    transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
-}
-
-.multiselect :global(.searchBox:hover) {
-    border-color: var(--highlight-color);
-}
-
-.multiselect :global(.searchBox input) {
-    color: var(--text-color);
-    font-size: var(--font-size-sm);
-    padding: 0;
-    margin-left: var(--spacing-sm);
-}
-
-.multiselect :global(.searchBox input::placeholder) {
-    color: var(--placeholder-color);
-    opacity: 1;
-}
-
-.multiselect :global(.chip) {
-    background: var(--highlight-color);
-    color: white;
-    border-radius: var(--radius-sm);
-    padding: var(--spacing-xs) var(--spacing-sm);
-    margin: 2px;
-    display: inline-flex;
-    align-items: center;
-}
-
-.multiselect :global(.chip .iconClose) {
-    fill: white;
-    margin-left: var(--spacing-xs);
-    cursor: pointer;
-}
-
-.multiselect :global(.optionListContainer) {
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius-md);
-    margin-top: var(--spacing-xs);
-    box-shadow: var(--shadow-md);
-}
-
-.multiselect :global(.optionContainer li) {
-    padding: var(--spacing-sm) var(--spacing-md);
-    font-size: var(--font-size-sm);
-    cursor: pointer;
-    transition: background-color var(--transition-fast);
-    color: var(--color-text-primary);
-}
-
-.multiselect :global(.optionContainer li:hover) {
-    background-color: var(--background-hover);
-    color: var(--color-text-primary);
-}
-
-.multiselect :global(.optionContainer li.highlightOption) {
-    background-color: var(--color-background-secondary);
-    color: var(--color-text-primary); /* Explicit text color */
-}
-
-/* Add this new rule for selected items */
-.multiselect :global(.optionContainer li.selected) {
-    background-color: var(--color-primary);
-    color: var(--color-text-light);
-}
-
-.multiselect :global(.checkbox) {
-    margin-right: var(--spacing-sm);
-    accent-color: var(--highlight-color);
-}
-
-/* Error state */
-.error :global(.searchBox) {
-    border-color: var(--error-color);
-}
-
-.error :global(.searchBox:focus-within) {
-    box-shadow: 0 0 0 2px rgba(220, 53, 69, 0.25);
-}
-
-/* Disabled state */
-.multiselect:global(.disabled) {
-    background: var(--disabled-bg);
-    opacity: 0.7;
-    cursor: not-allowed;
-}
-
-.multiselect:global(.disabled .searchBox) {
-    background: var(--disabled-bg);
-    pointer-events: none;
-}
-
-/* Single select variant */
-.multiselect:global(.singleSelect) {
-    --ms-bg: transparent;
-}
-
-/* Focus state */
-.multiselect :global(.searchBox:focus-within) {
-    border-color: var(--highlight-color);
-    box-shadow: var(--shadow-focus);
+    position: absolute;
+    bottom: -1.25rem;
+    left: 0;
 }

--- a/component/common/MultiSelectDropdown/MultiSelectDropdown.tsx
+++ b/component/common/MultiSelectDropdown/MultiSelectDropdown.tsx
@@ -1,79 +1,135 @@
-import React, { useRef } from "react";
-import Multiselect from "multiselect-react-dropdown";
-import styles from "./MultiSelectDropdown.module.css";
+import React from 'react';
+import Select from 'react-select';
+import styles from './MultiSelectDropdown.module.css';
+
+export interface OptionType {
+    value: string;
+    label: string;
+}
 
 interface MultiSelectDropdownProps {
     label: string;
-    options: { name: string; id: number }[];
-    selectedValues?: { name: string; id: number }[];
-    onChange: (selectedList: { name: string; id: number }[]) => void;
+    value: OptionType[] | null;
+    onChange: (selected: OptionType[] | null) => void;
+    options: OptionType[];
     required?: boolean;
     errorMessage?: string;
+    name?: string;
+    isDisabled?: boolean;
     placeholder?: string;
-    showCheckbox?: boolean;
-    selectionLimit?: number;
-    singleSelect?: boolean;
-    disabled?: boolean;
-    closeOnSelect?: boolean;
-    hidePlaceholder?: boolean;
-    className?: string;
 }
 
 const MultiSelectDropdown: React.FC<MultiSelectDropdownProps> = ({
                                                                      label,
-                                                                     options,
-                                                                     selectedValues = [],
+                                                                     value,
                                                                      onChange,
+                                                                     options,
                                                                      required = false,
-                                                                     errorMessage ,
-                                                                     placeholder = "Select options",
-                                                                     showCheckbox = false,
-                                                                     selectionLimit = -1,
-                                                                     singleSelect = false,
-                                                                     disabled = false,
-                                                                     closeOnSelect = true,
-                                                                     hidePlaceholder = false,
-                                                                     className = "",
+                                                                     errorMessage,
+                                                                     name,
+                                                                     isDisabled = false,
+                                                                     placeholder = '-- Select an option --',
                                                                  }) => {
-    const multiSelectRef = useRef<Multiselect>(null);
-
-    const handleSelect = (selectedList: { name: string; id: number }[]) => {
-        onChange(selectedList);
-    };
-
-    const handleRemove = (selectedList: { name: string; id: number }[]) => {
-        onChange(selectedList);
-    };
-
     return (
-        <div className={`${styles.container} ${className} ${errorMessage ? styles.error : ""}`}>
+        <div className={styles.inputContainer}>
             <label className={styles.label}>
                 {label}
-                {required && <span className={styles.required}>*</span>}
+                {required && <span className={styles.requiredAsterisk}>*</span>}
             </label>
-
-            <div className={styles.wrapper}>
-                <Multiselect
-                    ref={multiSelectRef}
+            <div className={styles.selectWrapper}>
+                <Select
+                    isMulti
+                    classNamePrefix="custom-select"
+                    value={value}
+                    onChange={(selected) => onChange(selected as OptionType[])}
                     options={options}
-                    selectedValues={selectedValues}
-                    onSelect={handleSelect}
-                    onRemove={handleRemove}
-                    displayValue="name"
-                    showCheckbox={showCheckbox}
-                    selectionLimit={selectionLimit}
-                    singleSelect={singleSelect}
+                    isDisabled={isDisabled}
+                    name={name}
                     placeholder={placeholder}
-                    disable={disabled}
-                    showArrow={true}
-                    closeOnSelect={closeOnSelect}
-                    hidePlaceholder={hidePlaceholder}
-                    avoidHighlightFirstOption={true}
-                    isObject={true}
-                    className={styles.multiselect}
+                    isClearable
+                    styles={{
+                        control: (base, state) => ({
+                            ...base,
+                            width: '100%',
+                            backgroundColor: 'var(--color-text-light)',
+                            borderColor: state.isFocused
+                                ? 'var(--color-border-focus)'
+                                : 'var(--color-border)',
+                            boxShadow: state.isFocused ? 'var(--shadow-focus)' : 'none',
+                            '&:hover': {
+                                borderColor: 'var(--color-primary-hover)',
+                            },
+                            padding: 'var(--spacing-xxs)',
+                            borderRadius: 'var(--radius-md)',
+                            minHeight: '40px',
+                            fontSize: 'var(--font-size-base)',
+                        }),
+                        option: (base, state) => ({
+                            ...base,
+                            backgroundColor: state.isSelected
+                                ? 'var(--color-primary-light)'
+                                : state.isFocused
+                                    ? 'var(--color-background-accent)'
+                                    : 'var(--color-white)',
+                            color: 'var(--color-text-primary)',
+                            cursor: 'pointer',
+                            fontSize: 'var(--font-size-base)',
+                            padding: 'var(--spacing-sm) var(--spacing-md)',
+                        }),
+                        multiValue: (base) => ({
+                            ...base,
+                            backgroundColor: 'var(--color-primary-light)',
+                            borderRadius: 'var(--radius-sm)',
+                        }),
+                        multiValueLabel: (base) => ({
+                            ...base,
+                            color: 'var(--color-text-primary)',
+                            fontWeight: '500',
+                            padding: 'var(--spacing-xxs) var(--spacing-xs)',
+                        }),
+                        multiValueRemove: (base) => ({
+                            ...base,
+                            color: 'var(--color-primary-dark)',
+                            ':hover': {
+                                backgroundColor: 'var(--color-primary-hover)',
+                                color: 'var(--color-white)',
+                            },
+                        }),
+                        placeholder: (base) => ({
+                            ...base,
+                            color: 'var(--color-placeholder)',
+                            fontSize: 'var(--font-size-base)',
+                        }),
+                        singleValue: (base) => ({
+                            ...base,
+                            color: 'var(--color-text-primary)',
+                            fontSize: 'var(--font-size-base)',
+                        }),
+                        menu: (base) => ({
+                            ...base,
+                            minWidth: '100%',
+                            zIndex: 'var(--z-index-dropdown)',
+                            boxShadow: 'var(--shadow-md)',
+                            borderRadius: 'var(--radius-md)',
+                        }),
+                        menuList: (base) => ({
+                            ...base,
+                            padding: 'var(--spacing-xs) 0',
+                        }),
+                        indicatorSeparator: (base) => ({
+                            ...base,
+                            backgroundColor: 'var(--color-border)',
+                        }),
+                        dropdownIndicator: (base) => ({
+                            ...base,
+                            color: 'var(--color-placeholder)',
+                            ':hover': {
+                                color: 'var(--color-text-secondary)',
+                            },
+                        }),
+                    }}
                 />
             </div>
-
             {errorMessage && <div className={styles.errorMessage}>{errorMessage}</div>}
         </div>
     );

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "qrcode.react": "^4.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-icons": "^5.5.0"
+    "react-icons": "^5.5.0",
+    "react-select": "^5.10.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
- Replaced deprecated 'multiselect-react-dropdown' with 'react-select' for better accessibility and customizability.
- Updated MultiSelectDropdown component to use react-select with full style overrides.
- Simplified and modernized CSS by removing unused and redundant styles.
- Updated XadesConfigForm to use the new MultiSelectDropdown with dynamic options and selected state handling.
- Synced selected algorithm values with form state and dropdown.
- Installed 'react-select' package in dependencies.